### PR TITLE
Fix hashing and chunking utilities

### DIFF
--- a/services/embed/chunking.py
+++ b/services/embed/chunking.py
@@ -1,38 +1,51 @@
 from __future__ import annotations
 from typing import Dict, Iterable, List
-import textwrap
-
-
 
 
 def chunk(core_doc: Dict, max_chars: int = 1000, overlap: int = 120) -> List[Dict]:
-text = core_doc["text"]
-if not text:
-return []
-parts: List[str] = []
-start = 0
-n = len(text)
-while start < n:
-end = min(start + max_chars, n)
-parts.append(text[start:end])
-start = end - overlap if end < n else end
-if start < 0:
-start = 0
-chunks = []
-for i, p in enumerate(parts):
-chunks.append({
-"doc_id": core_doc["source_id"],
-"chunk_id": f"{core_doc['source_id']}::{i}",
-"text": p,
-"metadata": {k: core_doc.get(k) for k in ("source","doc_type","country","tags","title")},
-})
-return chunks
+    """Split a document into overlapping text chunks.
 
+    The previous implementation built an intermediate list of string parts before
+    constructing chunk dictionaries.  This version constructs the chunk metadata
+    directly during iteration to reduce memory usage and simplify the logic.
+    """
 
+    text = core_doc["text"]
+    if not text:
+        return []
+
+    n = len(text)
+    chunks: List[Dict] = []
+    start = 0
+    i = 0
+    while True:
+        end = min(start + max_chars, n)
+        part = text[start:end]
+
+        chunks.append(
+            {
+                "doc_id": core_doc["source_id"],
+                "chunk_id": f"{core_doc['source_id']}::{i}",
+                "text": part,
+                "metadata": {
+                    k: core_doc.get(k)
+                    for k in ("source", "doc_type", "country", "tags", "title")
+                },
+            }
+        )
+
+        if end == n:
+            break
+        start = max(end - overlap, 0)
+        i += 1
+
+    return chunks
 
 
 def iter_chunks(normalized_docs: Iterable[Dict]) -> Iterable[Dict]:
-for nd in normalized_docs:
-core = {k: v for k, v in nd.items() if k not in ("facet", "raw")}
-for c in chunk(core):
-yield c
+    """Yield chunks for a stream of normalized documents."""
+
+    for nd in normalized_docs:
+        core = {k: v for k, v in nd.items() if k not in ("facet", "raw")}
+        for c in chunk(core):
+            yield c

--- a/services/ingest/utils_hash.py
+++ b/services/ingest/utils_hash.py
@@ -2,13 +2,15 @@ import hashlib
 from typing import Optional
 
 
-
-
 def content_hash(text: str, facet_json: Optional[str] = None) -> str:
+    """Compute a stable hash for a document's text and optional facet."""
+
     h = hashlib.sha256()
     h.update(text.encode("utf-8"))
-    if facet_json: 
+    if facet_json:
+        # Separate the facet content from the text with a null byte so that
+        # `text='ab', facet='c'` does not collide with `text='a', facet='bc'`.
         h.update(b"\x00")
         h.update(facet_json.encode("utf-8"))
-        
-        return h.hexdigest()
+
+    return h.hexdigest()

--- a/services/ingest/utils_id.py
+++ b/services/ingest/utils_id.py
@@ -1,25 +1,18 @@
 from urllib.parse import urlsplit
 
 
-
-
 def source_id_url(url: str) -> str:
     return f"url:{url}"
-
-
 
 
 def source_id_pdf(path: str) -> str:
     return f"pdf:{path}"
 
 
-
-
 def source_id_kv(namespace: str, key: str) -> str:
-# Generic helper e.g., ("ecb_fx", "2025-08-20") -> "ecb_fx:2025-08-20"
+    """Generic helper e.g., ("ecb_fx", "2025-08-20") -> "ecb_fx:2025-08-20"."""
+
     return f"{namespace}:{key}"
-
-
 
 
 def canonical_host(url: str) -> str:


### PR DESCRIPTION
## Summary
- ensure content_hash always returns a digest and properly mixes facet data
- document and clean helper functions in utils_id
- optimize and validate chunking by constructing chunk metadata in a single pass

## Testing
- `python -m py_compile services/embed/chunking.py services/ingest/utils_hash.py services/ingest/utils_id.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6200d7b2083248361005b4e0add95