### PR TITLE
feat: add session export and glossary page

### DIFF
--- a/rover-learn/README.md
+++ b/rover-learn/README.md
@@ -32,3 +32,18 @@ Open <http://localhost:3000>
 ```
 { _id, title, createdAt, updatedAt, status, segmentsCount }
 ```
+
+## Phase 3: Exports & Glossary
+
+### Exports
+
+From Session detail, click **Export** → files are written under
+`exports/sessions/<date>/<id>/`.
+
+- `transcript_src.txt` – concatenated `textSrc`
+- `translation_en.txt` – concatenated `textEn`
+- `segments.jsonl` – one JSON segment per line
+
+### Glossary
+
+View terms at `/glossary`. Source: `config/glossary.csv`.

--- a/rover-learn/frontend/src/app/glossary/page.tsx
+++ b/rover-learn/frontend/src/app/glossary/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { getGlossary } from '../../lib/api';
+
+interface Item {
+  term: string;
+  de: string;
+  en: string;
+  notes: string;
+}
+
+export default function GlossaryPage() {
+  const [items, setItems] = useState<Item[]>([]);
+  useEffect(() => {
+    getGlossary().then(setItems);
+  }, []);
+
+  const cell = { border: '1px solid #ccc', padding: '0.25rem' } as const;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Glossary ({items.length} terms)</h1>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th style={cell}>term</th>
+            <th style={cell}>de</th>
+            <th style={cell}>en</th>
+            <th style={cell}>notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((g, i) => (
+            <tr key={i}>
+              <td style={cell}>{g.term}</td>
+              <td style={cell}>{g.de}</td>
+              <td style={cell}>{g.en}</td>
+              <td style={cell}>{g.notes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/rover-learn/frontend/src/app/layout.tsx
+++ b/rover-learn/frontend/src/app/layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <aside style={{ width: '200px', background: '#f0f0f0', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
             <Link href="/">Live</Link>
             <Link href="/sessions">Sessions</Link>
+            <Link href="/glossary">Glossary</Link>
           </aside>
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
             <div style={{ height: '40px', background: '#ddd', padding: '0.5rem' }}>Status Bar</div>

--- a/rover-learn/frontend/src/app/sessions/[id]/page.tsx
+++ b/rover-learn/frontend/src/app/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { apiGet } from '../../../lib/api';
+import { apiGet, exportSession } from '../../../lib/api';
 
 interface Segment {
   textSrc: string;
@@ -12,6 +12,9 @@ export default function SessionDetail({ params }: { params: { id: string } }) {
   const [session, setSession] = useState<
     { title: string; segments: Segment[]; segmentsCount: number } | null
   >(null);
+  const [exportInfo, setExportInfo] = useState<
+    { exportDir: string; files: string[] } | null
+  >(null);
 
   useEffect(() => {
     apiGet(`/sessions/${id}`).then(setSession);
@@ -22,8 +25,23 @@ export default function SessionDetail({ params }: { params: { id: string } }) {
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ padding: '1rem' }}>
-        <h1>{session.title}</h1>
-        <p>Segments ({session.segmentsCount})</p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <div>
+            <h1>{session.title}</h1>
+            <p>Segments ({session.segmentsCount})</p>
+          </div>
+          <button onClick={() => exportSession(id).then(setExportInfo)}>Export</button>
+        </div>
+        {exportInfo && (
+          <div style={{ background: '#e0ffe0', padding: '0.5rem', marginTop: '0.5rem' }}>
+            <p>Exported to: {exportInfo.exportDir}</p>
+            <ul>
+              {exportInfo.files.map((f) => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
       <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
         <div style={{ overflowY: 'auto', padding: '1rem', borderRight: '1px solid #ccc' }}>

--- a/rover-learn/frontend/src/lib/api.ts
+++ b/rover-learn/frontend/src/lib/api.ts
@@ -7,12 +7,12 @@ export async function apiGet(path: string) {
   return res.json();
 }
 
-export async function apiPost(path: string, data: any) {
+export async function apiPost(path: string, data?: any) {
   const res = await fetch(`${BASE_URL}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     mode: "cors",
-    body: JSON.stringify(data),
+    body: data !== undefined ? JSON.stringify(data) : undefined,
   });
   if (!res.ok) throw new Error(`POST ${path} -> ${res.status}`);
   return res.json();
@@ -25,4 +25,12 @@ export function connectWs(sessionId: string) {
 
 export async function startSession(title?: string) {
   return apiPost("/sessions/start", { title: title || null });
+}
+
+export async function exportSession(id: string) {
+  return apiPost(`/export/${id}`);
+}
+
+export async function getGlossary() {
+  return apiGet(`/glossary`);
 }


### PR DESCRIPTION
## Summary
- add backend export endpoints writing transcripts, translations, and segments
- expose export button and glossary page in frontend
- document exports and glossary usage

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6e05b05488324bf956026cdcdc9e9