### PR TITLE
feat: add ASR stub and wire backend

### DIFF
--- a/rover-learn/README.md
+++ b/rover-learn/README.md
@@ -64,3 +64,18 @@ On first run, the model will be downloaded to your HF cache.
 2. `uvicorn services.mt.server:app --port 4002`
 3. `uvicorn backend.app:app --port 4000`
 4. `cd frontend && npm run dev`
+
+## Phase 5: ASR stub
+
+Start a tiny ASR service:
+
+```
+uvicorn services.asr.server:app --host 0.0.0.0 --port 4001 --reload
+```
+
+### Dev run order reminder
+
+1. `uvicorn services.asr.server:app --port 4001`
+2. `uvicorn services.mt.server:app --port 4002`
+3. `uvicorn backend.app:app --port 4000`
+4. `cd frontend && npm run dev`

--- a/rover-learn/services/asr/server.py
+++ b/rover-learn/services/asr/server.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+GERMAN_TOKENS = {"der", "die", "und"}
+
+
+class TranscribeIn(BaseModel):
+    text: str
+    idx: int
+
+
+def _detect_lang(text: str) -> str:
+    t = text.lower()
+    if any(tok in t.split() for tok in GERMAN_TOKENS) or any(ch in t for ch in "äöüß"):
+        return "de"
+    return "en"
+
+
+@app.get("/health")
+def health():
+    return {"service": "asr", "status": "ok"}
+
+
+@app.post("/transcribe")
+def transcribe(payload: TranscribeIn):
+    lang = _detect_lang(payload.text)
+    idx = payload.idx
+    return {
+        "idx": idx,
+        "tStart": idx * 1.0,
+        "tEnd": idx * 1.0 + 0.9,
+        "lang": lang,
+        "speaker": "Speaker 1",
+        "textSrc": payload.text,
+        "partial": False,
+        "confidence": 0.95,
+    }


### PR DESCRIPTION
## Summary
- add simple FastAPI ASR service stub with language detection
- route realtime segments through ASR and translate German lines
- document ASR stub and startup order

## Testing
- `python -m py_compile rover-learn/services/asr/server.py rover-learn/backend/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6e3c3c034832480c69899c92d85b1