### PR TITLE
fix: detect local llama server on Windows

### DIFF
--- a/rover-learn/README.md
+++ b/rover-learn/README.md
@@ -188,6 +188,11 @@ Live uses 500 ms chunks with WebRTC VAD and ~0.6–0.8 s endpointing so typi
 llama-server --model phi-3.5
 ```
 
+The backend looks for the binary either in your `PATH` or under
+`llama/llama-server(.exe)` at the project root. On Windows keep the
+executable as `llama-server.exe` in that folder if it's not globally
+available.
+
 Requests use strict prompts and expect JSON-only responses.
 
 ## Phase 11: Hotkeys & Settings

--- a/rover-learn/services/llm/client.py
+++ b/rover-learn/services/llm/client.py
@@ -2,10 +2,38 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+import shutil
+from pathlib import Path
 
 import httpx
 
 LLM_URL = os.getenv("LLM_URL", "http://127.0.0.1:8080")
+
+
+def _ensure_local_llama() -> None:
+    """Ensure `llama-server` binary is discoverable.
+
+    If the binary isn't available in PATH, also look for
+    `llama/llama-server(.exe)` relative to repo root. This helps Windows
+    setups where the executable lives in a `llama` folder.
+    """
+
+    # already on PATH
+    if shutil.which("llama-server"):
+        return
+
+    root = Path(__file__).resolve().parents[2]
+    exe_name = "llama-server.exe" if os.name == "nt" else "llama-server"
+    local = root / "llama" / exe_name
+    if local.exists():
+        os.environ["PATH"] = str(local.parent) + os.pathsep + os.environ.get("PATH", "")
+    else:
+        print("warning: llama-server not found in PATH or local llama directory", file=sys.stderr)
+
+
+_ensure_local_llama()
+
 HTTP = httpx.AsyncClient(timeout=30.0)
 
 


### PR DESCRIPTION
## Summary
- ensure `llama-server` binary is detected in PATH or `llama/` folder, including `.exe` on Windows
- document where `llama-server` is searched for

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c73808787c8324b0819fa5c0136df6